### PR TITLE
Write assets to a temporary directory before calling out to sass

### DIFF
--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -1,94 +1,148 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
+import 'dart:collection';
+
+import 'package:barback/barback.dart' show BarbackSettings;
 import 'package:build/build.dart';
 import 'package:logging/logging.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart';
 import 'package:sass/sass.dart';
+import 'package:scratch_space/scratch_space.dart';
 
+final outputExtensionKey = 'outputExtension';
+final _packageNameRegExp = new RegExp(r'''package:([^\/]*)\/''');
+final _packagePathRegExp = new RegExp(r'''package:[^\/]*\/(.*)''');
+final _importBlockRegExp = new RegExp(r'''@import ([^;]*);''', multiLine: true);
+final _fileNameRegExp = new RegExp(r'''(?:\'|\")([^\'\"]*)(?:\'|\")''');
+final _sassCommentRegExp =
+    new RegExp(r'''//.*?\n|/\*.*?\*/''', multiLine: true);
+
+/// A `Builder` to compile .css files from .scss source using dart-sass.
+///
+/// NOTE: Because Sass requires reading from the disk this `Builder` copies all
+/// `Assets` to a temporary directory with a structure similar to that defined
+/// in `.packages`. Sass will read from the temporary directory when compiling.
 class SassBuilder implements Builder {
-
   Logger _log = new Logger('SassBuilder');
+  String _outputExtension;
+  static final _scratchSpaceResource = new Resource<ScratchSpace>(
+          () => new ScratchSpace(),
+      dispose: (temp) => temp.delete());
 
-  Set<AssetId> _mainInputs;
-
-  Set<AssetId> get mainInputs {
-    if (_mainInputs == null) {
-      var sassBuildFile = new File(join(Directory.current.path, '.dart_tool', 'sass_build_main_inputs.json'));
-      _log.info('reading main_inputs file: ${sassBuildFile}');
-      if (sassBuildFile.existsSync()) {
-        var mainInputsJson = sassBuildFile.readAsStringSync();
-        mainInputsJson = mainInputsJson.isEmpty ? '[]' : mainInputsJson;
-        List mainInputsList = JSON.decode(mainInputsJson);
-        mainInputsList = mainInputsList == null || mainInputsList.isEmpty ? [] : mainInputsList;
-        _mainInputs = new Set();
-        var rewriteInputs = false;
-        for (var mainInputAssetIdName in mainInputsList) {
-          var mainInputAssetId = new AssetId.parse(mainInputAssetIdName);
-          if (new File(mainInputAssetId.path).existsSync()) {
-            _log.info('adding mainInputFile: ${mainInputAssetId}');
-            _mainInputs.add(mainInputAssetId);
-          } else {
-            rewriteInputs = true;
-          }
-        }
-        if (rewriteInputs) {
-          _log.info('rewriting inputs');
-          _saveMainInputs();
-        }
-      } else {
-        _mainInputs = new Set();
-      }
+  SassBuilder({BarbackSettings settings}) {
+    if (settings != null) {
+      _outputExtension = settings.configuration.containsKey(outputExtensionKey)
+          ? settings.configuration[outputExtensionKey]
+          : '.css';
+    } else {
+      _outputExtension = '.css';
     }
-    return _mainInputs;
-  }
-
-  _saveMainInputs() {
-    var sassBuildFile = new File(join(Directory.current.path, '.dart_tool', 'sass_build_main_inputs.json'));
-    if (!sassBuildFile.existsSync()) sassBuildFile.createSync(recursive: true);
-
-    _log.info('writing mainInputs: $_mainInputs');
-    sassBuildFile.writeAsStringSync(JSON.encode(_mainInputs.map((mi) => mi.toString()).toList()));
   }
 
   @override
   Future build(BuildStep buildStep) async {
     var inputId = buildStep.inputId;
-    _log.info('processing changed file: ${inputId}');
 
-    if (!basename(inputId.path).startsWith('_')) {
-      if (!mainInputs.contains(inputId)) {
-        mainInputs.add(inputId);
-        _saveMainInputs();
-      }
+    if (basename(inputId.path).startsWith('_')) {
+      // Do not produce any output for .scss partials.
+      _log.fine('skipping parial file: ${inputId}');
+      return;
     }
-    _log.info('using mainInputs: $mainInputs');
 
-    if (mainInputs.isNotEmpty) {
-      var mainInputsToRemove = new Set();
-      for (var mainInput in mainInputs) {
-        _log.info('parsing: ${mainInput}');
-        if (!new File(mainInput.path).existsSync()) {
-          _log.info('adding mainInput to remove: $mainInput');
-          mainInputsToRemove.add(mainInput);
-          continue;
-        }
-        var css = await compile(mainInput.path, packageResolver: await PackageResolver.current.asSync);
-//        buildStep.writeAsString(_changeExtension(mainInput), css);
-        var file = new File(mainInput
-            .changeExtension('.css')
-            .path);
-        file.createSync(recursive: true);
-        file.writeAsString(css);
-      }
+    // Read and copy this asset and all imported assets to the temp directory.
+    _log.fine('processing file: ${inputId}');
+    var tempDir =
+        await buildStep.fetchResource<ScratchSpace>(_scratchSpaceResource);
+    await _readAndCopyImports(inputId, buildStep, tempDir);
 
-      _log.info('removing mainInputs non existing');
-      mainInputs.removeAll(mainInputsToRemove);
-    }
+    // Compile the css.
+    var tempAssetPath = tempDir.fileFor(inputId).path;
+    _log.fine('compiling file: ${tempAssetPath}');
+    var cssOutput = compile(tempAssetPath,
+        packageResolver: new SyncPackageResolver.root(tempDir.packagesDir.uri));
+
+    // Write the builder output
+    var outputId = inputId.changeExtension(_outputExtension);
+    buildStep.writeAsString(outputId, '${cssOutput}\n');
+    _log.fine('wrote css file: ${outputId.path}');
   }
 
   @override
-  Map<String, List<String>> get buildExtensions =>
-      {'': const ['.css']}; // since we are writing files without buildStep, we need to have a fake extension
+  Map<String, List<String>> get buildExtensions => {
+        '.scss': [_outputExtension],
+        '.sass': [_outputExtension],
+      };
+
+  // Reads `id` and all transitive imports while copying them to `tempDir`.
+  //
+  // Uses `buildStep to read the assets and the `ScratchSpace` API to write
+  // `tempDir`.
+  Future _readAndCopyImports(
+      AssetId id, BuildStep buildStep, ScratchSpace tempDir) async {
+    var assetsToCopy = new Queue<AssetId>();
+    assetsToCopy.add(id);
+
+    while (assetsToCopy.isNotEmpty) {
+      id = assetsToCopy.removeFirst();
+
+      var contents = await buildStep.readAsString(id);
+      _log.fine('read file: ${id}');
+      await tempDir.ensureAssets([id], buildStep);
+
+      var imports = await _importedAssets(id, contents, buildStep);
+      assetsToCopy.addAll(imports);
+      var importLog = imports.fold('', (acc, import) => '$acc\n  ${import}');
+      _log.fine('found imports:$importLog');
+    }
+  }
+
+  // Returns the `AssetId`s of all the scss imports in `contents`.
+  Future<Iterable<AssetId>> _importedAssets(
+      AssetId id, String contents, BuildStep buildStep) async {
+    var importedAssets = new Set<AssetId>();
+
+    for (var importBlock in _importBlockRegExp
+        .allMatches(contents.replaceAll(_sassCommentRegExp, ''))) {
+      var imports = _fileNameRegExp.allMatches(importBlock.group(1));
+      for (var import in imports) {
+        var importId = new AssetId(_importPackage(import.group(1), id.package),
+            _importPath(import.group(1), id.path));
+
+        if (!await (buildStep.canRead(importId))) {
+          // Try same asset path except filename starting with an underscore.
+          _log.fine('could not read file: ${importId}');
+          importId = new AssetId(importId.package,
+              join(dirname(importId.path), '_${basename(importId.path)}'));
+        }
+
+        if (!await buildStep.canRead(importId)) {
+          // Only copy imports that are found. If there is a problem with a
+          // missing file, let sass compilation fail and report it.
+          _log.severe('could not read file: ${importId}');
+          continue;
+        }
+
+        importedAssets.add(importId);
+      }
+    }
+
+    return importedAssets;
+  }
+
+  // Returns the package name parsed from the given `import` or defaults to
+  // `currentPackage`.
+  String _importPackage(String import, String currentPackage) =>
+      import.startsWith('package:')
+          ? _packageNameRegExp.firstMatch(import).group(1)
+          : currentPackage;
+
+  // Returns the path parsed from the given `import` or defaults to
+  // locating the file in the `currentPath`.
+  String _importPath(String import, String currentPath) {
+    var path = import.startsWith('package:')
+        ? join('lib', _packagePathRegExp.firstMatch(import).group(1))
+        : join(dirname(currentPath), import);
+
+    return path.endsWith('.scss') ? path : '$path.scss';
+  }
 }

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -1,0 +1,8 @@
+import 'package:build_barback/build_barback.dart';
+import 'sass_builder.dart';
+
+/// A pub transformer simply wrapping the [SassBuilder].
+class SassBuilderTransform extends BuilderTransformer {
+  SassBuilderTransform.asPlugin(settings)
+      : super(new SassBuilder(settings: settings));
+}

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -1,8 +1,20 @@
+import 'package:barback/barback.dart';
 import 'package:build_barback/build_barback.dart';
 import 'sass_builder.dart';
 
 /// A pub transformer simply wrapping the [SassBuilder].
 class SassBuilderTransform extends BuilderTransformer {
-  SassBuilderTransform.asPlugin(settings)
-      : super(new SassBuilder(settings: settings));
+  static final _outputExtensionKey = 'outputExtension';
+  SassBuilderTransform() : super(new SassBuilder());
+
+  SassBuilderTransform.customExtension(String outputExtension)
+      : super(new SassBuilder(outputExtension: outputExtension));
+
+  factory SassBuilderTransform.asPlugin(BarbackSettings settings) {
+    if (settings.configuration.containsKey(_outputExtensionKey)) {
+      return new SassBuilderTransform.customExtension(
+          settings.configuration[_outputExtensionKey]);
+    }
+    return new SassBuilderTransform();
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   sass: ^1.0.0-beta.2
   build: ^0.10.1
+  build_barback: ^0.4.0+1
   build_runner: ^0.4.0
   logging: ^0.11.3
   package_resolver: ^1.0.2
@@ -17,5 +18,3 @@ dev_dependencies:
   bootstrap_sass: 4.0.0-alpha.5+1
   build_test: ^0.8.0
   test: ^0.12.0
-#  bootstrap_sass:
-#    path: ../bootstrap_sass

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,13 +6,16 @@ description: Transpile sass files using the "build" package.
 environment:
   sdk: '>=1.8.0 <2.0.0'
 dependencies:
-  sass: ^1.0.0-alpha.9
-  build: ^0.10.0
+  sass: ^1.0.0-beta.2
+  build: ^0.10.1
   build_runner: ^0.4.0
   logging: ^0.11.3
   package_resolver: ^1.0.2
   path: ^1.4.1
+  scratch_space: ^0.0.1
 dev_dependencies:
   bootstrap_sass: 4.0.0-alpha.5+1
+  build_test: ^0.8.0
+  test: ^0.12.0
 #  bootstrap_sass:
 #    path: ../bootstrap_sass

--- a/sass_builder_test.dart
+++ b/sass_builder_test.dart
@@ -1,0 +1,207 @@
+import 'package:build/build.dart';
+import 'package:build_barback/build_barback.dart';
+import 'package:build_test/build_test.dart';
+import 'package:sass_builder/sass_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // These tests only verify which assets are read and written by the
+  // SassBuilder. This is because the inputs are being parsed to find what files
+  // they import.
+  //
+  // These tests do not verify any output as that is determined by the sass
+  // implementation.
+  group('File import parsing tests', () {
+    SassBuilder builder;
+    InMemoryAssetWriter writer;
+    InMemoryAssetReader reader;
+
+    setUp(() {
+      builder = new SassBuilder();
+      reader = new InMemoryAssetReader();
+      writer = new InMemoryAssetWriter();
+    });
+
+    test('no imports, one read and one write', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var inputs = {
+        primary: '/* no imports */',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(1));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(1));
+      expect(reader.assetsRead, contains(primary));
+     });
+
+    test('one relative partial import', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import = makeAssetId('a|lib/_more_styles.scss');
+      var inputs = {
+        primary: '''@import '_more_styles.scss';''',
+        import: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import, inputs[import]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(1));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(2));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import));
+    });
+
+    test('one relative partial import simplified name', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import = makeAssetId('a|lib/_more_styles.scss');
+      var inputs = {
+        primary: '''@import 'more_styles';''',
+        import: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import, inputs[import]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(1));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(2));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import));
+    });
+
+    test('one relative import', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import = makeAssetId('a|lib/foo/more_styles.scss');
+      var inputs = {
+        primary: '''@import 'foo/more_styles';''',
+        import: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import, inputs[import]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(2));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+      expect(writer.assets, contains(import.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(2));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import));
+    });
+
+    test('one package import', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import = makeAssetId('b|lib/_more_styles.scss');
+      var inputs = {
+        primary: '''@import 'package:b/more_styles';''',
+        import: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import, inputs[import]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(1));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(2));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import));
+    });
+
+    test('multiple imports in one block', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import1 = makeAssetId('b|lib/more_styles.scss');
+      var import2 = makeAssetId('a|lib/_more_styles.scss');
+      var inputs = {
+        primary: '''@import 'package:b/more_styles','''
+                 '''        'more_styles';''',
+        import1: '''/* no imports */''',
+        import2: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import1, inputs[import1]);
+      reader.cacheStringAsset(import2, inputs[import2]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(2));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+      expect(writer.assets, contains(import1.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(3));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import1));
+      expect(reader.assetsRead, contains(import2));
+    });
+
+    test('multiple imports in multiple blocks', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import1 = makeAssetId('b|lib/more_styles.scss');
+      var import2 = makeAssetId('a|lib/_more_styles.scss');
+      var inputs = {
+        primary: '''@import 'package:b/more_styles';'''
+                 '''@import 'more_styles';''',
+        import1: '''/* no imports */''',
+        import2: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import1, inputs[import1]);
+      reader.cacheStringAsset(import2, inputs[import2]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(2));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+      expect(writer.assets, contains(import1.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(3));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import1));
+      expect(reader.assetsRead, contains(import2));
+    });
+
+    test('transitive imports', () async {
+      var primary = makeAssetId('a|lib/styles.scss');
+      var import1 = makeAssetId('b|lib/styles.scss');
+      var import2 = makeAssetId('b|lib/_more_styles.scss');
+      var inputs = {
+        primary: '''@import 'package:b/more_styles';''',
+        import1: '''@import 'more_styles';''',
+        import2: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import1, inputs[import1]);
+      reader.cacheStringAsset(import2, inputs[import2]);
+
+      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+
+      expect(writer.assets.length, equals(2));
+      expect(writer.assets, contains(primary.changeExtension('.css')));
+      expect(writer.assets, contains(import1.changeExtension('.css')));
+
+      expect(reader.assets.length, equals(3));
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import1));
+      expect(reader.assetsRead, contains(import2));
+    });
+  });
+}

--- a/test/sass_builder_test.dart
+++ b/test/sass_builder_test.dart
@@ -1,5 +1,4 @@
 import 'package:build/build.dart';
-import 'package:build_barback/build_barback.dart';
 import 'package:build_test/build_test.dart';
 import 'package:sass_builder/sass_builder.dart';
 import 'package:test/test.dart';
@@ -30,14 +29,11 @@ void main() {
 
       reader.cacheStringAsset(primary, inputs[primary]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(1));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
-
-      expect(reader.assets.length, equals(1));
-      expect(reader.assetsRead, contains(primary));
-     });
+      expect(writer.assets.keys, equals([primary.changeExtension('.css')]));
+      expect(reader.assetsRead, equals([primary]));
+    });
 
     test('one relative partial import', () async {
       var primary = makeAssetId('a|lib/styles.scss');
@@ -50,14 +46,10 @@ void main() {
       reader.cacheStringAsset(primary, inputs[primary]);
       reader.cacheStringAsset(import, inputs[import]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(1));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
-
-      expect(reader.assets.length, equals(2));
-      expect(reader.assetsRead, contains(primary));
-      expect(reader.assetsRead, contains(import));
+      expect(writer.assets.keys, equals([primary.changeExtension('.css')]));
+      expect(reader.assetsRead, unorderedEquals([primary, import]));
     });
 
     test('one relative partial import simplified name', () async {
@@ -71,12 +63,10 @@ void main() {
       reader.cacheStringAsset(primary, inputs[primary]);
       reader.cacheStringAsset(import, inputs[import]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(1));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
+      expect(writer.assets.keys, equals([primary.changeExtension('.css')]));
 
-      expect(reader.assets.length, equals(2));
       expect(reader.assetsRead, contains(primary));
       expect(reader.assetsRead, contains(import));
     });
@@ -92,15 +82,15 @@ void main() {
       reader.cacheStringAsset(primary, inputs[primary]);
       reader.cacheStringAsset(import, inputs[import]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(2));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
-      expect(writer.assets, contains(import.changeExtension('.css')));
-
-      expect(reader.assets.length, equals(2));
-      expect(reader.assetsRead, contains(primary));
-      expect(reader.assetsRead, contains(import));
+      expect(
+          writer.assets.keys,
+          unorderedEquals([
+            primary.changeExtension('.css'),
+            import.changeExtension('.css')
+          ]));
+      expect(reader.assetsRead, unorderedEquals([primary, import]));
     });
 
     test('one package import', () async {
@@ -114,12 +104,10 @@ void main() {
       reader.cacheStringAsset(primary, inputs[primary]);
       reader.cacheStringAsset(import, inputs[import]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(1));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
+      expect(writer.assets.keys, equals([primary.changeExtension('.css')]));
 
-      expect(reader.assets.length, equals(2));
       expect(reader.assetsRead, contains(primary));
       expect(reader.assetsRead, contains(import));
     });
@@ -130,7 +118,7 @@ void main() {
       var import2 = makeAssetId('a|lib/_more_styles.scss');
       var inputs = {
         primary: '''@import 'package:b/more_styles','''
-                 '''        'more_styles';''',
+            '''        'more_styles';''',
         import1: '''/* no imports */''',
         import2: '''/* no imports */''',
       };
@@ -139,13 +127,15 @@ void main() {
       reader.cacheStringAsset(import1, inputs[import1]);
       reader.cacheStringAsset(import2, inputs[import2]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(2));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
-      expect(writer.assets, contains(import1.changeExtension('.css')));
+      expect(
+          writer.assets.keys,
+          unorderedEquals([
+            primary.changeExtension('.css'),
+            import1.changeExtension('.css')
+          ]));
 
-      expect(reader.assets.length, equals(3));
       expect(reader.assetsRead, contains(primary));
       expect(reader.assetsRead, contains(import1));
       expect(reader.assetsRead, contains(import2));
@@ -157,7 +147,7 @@ void main() {
       var import2 = makeAssetId('a|lib/_more_styles.scss');
       var inputs = {
         primary: '''@import 'package:b/more_styles';'''
-                 '''@import 'more_styles';''',
+            '''@import 'more_styles';''',
         import1: '''/* no imports */''',
         import2: '''/* no imports */''',
       };
@@ -166,13 +156,15 @@ void main() {
       reader.cacheStringAsset(import1, inputs[import1]);
       reader.cacheStringAsset(import2, inputs[import2]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(2));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
-      expect(writer.assets, contains(import1.changeExtension('.css')));
+      expect(
+          writer.assets.keys,
+          unorderedEquals([
+            primary.changeExtension('.css'),
+            import1.changeExtension('.css')
+          ]));
 
-      expect(reader.assets.length, equals(3));
       expect(reader.assetsRead, contains(primary));
       expect(reader.assetsRead, contains(import1));
       expect(reader.assetsRead, contains(import2));
@@ -192,13 +184,15 @@ void main() {
       reader.cacheStringAsset(import1, inputs[import1]);
       reader.cacheStringAsset(import2, inputs[import2]);
 
-      await runBuilder(builder, inputs.keys, reader, writer, const BarbackResolvers());
+      await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.length, equals(2));
-      expect(writer.assets, contains(primary.changeExtension('.css')));
-      expect(writer.assets, contains(import1.changeExtension('.css')));
+      expect(
+          writer.assets.keys,
+          unorderedEquals([
+            primary.changeExtension('.css'),
+            import1.changeExtension('.css')
+          ]));
 
-      expect(reader.assets.length, equals(3));
       expect(reader.assetsRead, contains(primary));
       expect(reader.assetsRead, contains(import1));
       expect(reader.assetsRead, contains(import2));


### PR DESCRIPTION
* Copy primary assets and all transitive imports to a temporary directory. Build css using the copied sources. Ensures that all assets are available on disk before calling out to the sass compiler.
* Add a pub transformer that wraps `SassBuilder`.
* Add tests to validate parsing of imports.