### PR TITLE
Update to the latest build_runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dev_dependencies:
 }
 ```
 
-5\. Run either `pub run build_runner build` or `pub run build_runner watch` and
+4\. Run either `pub run build_runner build` or `pub run build_runner watch` and
     the file `web/main.css` will be generated to a hidden directory containing:
 
 ```css

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ dependencies:
     bootstrap_sass: any # this dependency is only for demo purposes
 dev_dependencies:
     sass_builder: ^1.0.0 # update for the latest version
+    build_runner: ^0.7.0
 ```
 
 2\. Create `web/main.scss` containing the following code:
@@ -40,36 +41,8 @@ dev_dependencies:
 }
 ```
 
-4\. Create `tool/build.dart` containing the following code:
-
-```dart
-import 'dart:async';
-
-import 'package:build_runner/build_runner.dart';
-import 'package:sass_builder/phase.dart';
-
-Future main() async {
-  await build([sassBuildAction], deleteFilesByDefault: true);
-}
-
-```
-
-You can also create `tool/watch.dart` with the following code:
-
-```dart
-import 'dart:async';
-
-import 'package:build_runner/build_runner.dart';
-import 'package:sass_builder/phase.dart';
-
-Future main() async {
-  await watch([sassBuildAction], deleteFilesByDefault: true);
-}
-
-```
-
-5\. Run either `tool/build.dart` or `tool/watch.dart` and the file `web/main.css`
-    will be generated containing:
+5\. Run either `pub run build_runner build` or `pub run build_runner watch` and
+    the file `web/main.css` will be generated to a hidden directory containing:
 
 ```css
 .b {

--- a/README.mdtmpl
+++ b/README.mdtmpl
@@ -15,6 +15,7 @@ dependencies:
     bootstrap_sass: any # this dependency is only for demo purposes
 dev_dependencies:
     sass_builder: ^1.0.0 # update for the latest version
+    build_runner: ^0.7.0
 ```
 
 2\. Create `web/main.scss` containing the following code:
@@ -25,16 +26,8 @@ dev_dependencies:
 
 {@example example/_sub.scss}
 
-4\. Create `tool/build.dart` containing the following code:
-
-{@example tool/build.dart}
-
-You can also create `tool/watch.dart` with the following code:
-
-{@example tool/watch.dart}
-
-5\. Run either `tool/build.dart` or `tool/watch.dart` and the file `web/main.css`
-    will be generated containing:
+5\. Run either `pub run build_runner build` or `pub run build_runner watch` and
+    the file `web/main.css` will be generated to a hidden directory containing:
 
 {@example example/main.css}
 

--- a/README.mdtmpl
+++ b/README.mdtmpl
@@ -26,7 +26,7 @@ dev_dependencies:
 
 {@example example/_sub.scss}
 
-5\. Run either `pub run build_runner build` or `pub run build_runner watch` and
+4\. Run either `pub run build_runner build` or `pub run build_runner watch` and
     the file `web/main.css` will be generated to a hidden directory containing:
 
 {@example example/main.css}

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,9 @@
+builders:
+  sass_builder:
+    target: "sass_builder"
+    import: "package:sass_builder/sass_builder.dart"
+    builder_factories: ["sassBuilder"]
+    auto_apply: dependents
+    build_extensions:
+      .scss: [".css"]
+      .sass: [".css"]

--- a/lib/phase.dart
+++ b/lib/phase.dart
@@ -1,8 +1,0 @@
-import 'package:build_runner/build_runner.dart';
-import 'package:sass_builder/sass_builder.dart';
-
-final _graph = new PackageGraph.forThisPackage();
-
-BuildAction get sassBuildAction =>
-    new BuildAction(new SassBuilder(), _graph.root.name,
-        inputs: ['**/*.scss', '**/*.sass']);

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -18,6 +18,8 @@ final _sassfileNameRegExp = new RegExp(r'''['"]?([^ ,'"]+)['"]?''');
 final _scssCommentRegExp =
     new RegExp(r'''//.*?\n|/\*.*?\*/''', multiLine: true);
 
+Builder sassBuilder(_) => new SassBuilder();
+
 /// A `Builder` to compile .css files from .scss source using dart-sass.
 ///
 /// NOTE: Because Sass requires reading from the disk this `Builder` copies all

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 dependencies:
   barback: ^0.15.2
   build: ^0.11.1
-  build_barback: ^0.4.0+2
-  build_runner: ^0.6.1
+  build_barback: ">=0.4.0+2 < 0.6.0"
+  build_config: ^0.2.1
   logging: ^0.11.3
   package_resolver: ^1.0.2
   path: ^1.4.1
@@ -21,4 +21,5 @@ dependencies:
 dev_dependencies:
   bootstrap_sass: 4.0.0-alpha.5+1
   build_test: ^0.9.1
+  build_runner: ^0.7.0
   test: ^0.12.0

--- a/tool/build.dart
+++ b/tool/build.dart
@@ -1,8 +1,0 @@
-import 'dart:async';
-
-import 'package:build_runner/build_runner.dart';
-import 'package:sass_builder/phase.dart';
-
-Future main() async {
-  await build([sassBuildAction], deleteFilesByDefault: true);
-}

--- a/tool/watch.dart
+++ b/tool/watch.dart
@@ -1,8 +1,0 @@
-import 'dart:async';
-
-import 'package:build_runner/build_runner.dart';
-import 'package:sass_builder/phase.dart';
-
-Future main() async {
-  await watch([sassBuildAction], deleteFilesByDefault: true);
-}


### PR DESCRIPTION
Offers a new workflow for users without writing a manual build script.
The most visible difference with this version is that files are
generated to a hidden directory rather than their source tree.

- Add a BuilderFactory method which takes a BuilderOptions
- Add a `build.yaml` to expose the Builder as something which can be run
  automatically
- Update the README to reference the `pub run` approach rather than the
  manual build script approach.