### PR TITLE
 Made regex for matching sass import rules a multiline regex.

### DIFF
--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -12,7 +12,8 @@ final _packageNameRegExp = new RegExp(r'''package:([^\/]*)\/''');
 final _packagePathRegExp = new RegExp(r'''package:[^\/]*\/(.*)''');
 final _scssImportBlockRegExp =
     new RegExp(r'''@import ([^;]*);''', multiLine: true);
-final _sassImportBlockRegExp = new RegExp(r'''@import (.*)$''');
+final _sassImportBlockRegExp =
+    new RegExp(r'''@import (.*)$''', multiLine: true);
 final _scssfileNameRegExp = new RegExp(r'''(?:\'|\")([^\'\"]*)(?:\'|\")''');
 final _sassfileNameRegExp = new RegExp(r'''['"]?([^ ,'"]+)['"]?''');
 final _scssCommentRegExp =

--- a/test/sass_builder_test.dart
+++ b/test/sass_builder_test.dart
@@ -245,5 +245,33 @@ void main() {
       expect(reader.assetsRead, contains(import1));
       expect(reader.assetsRead, contains(import2));
     });
+
+    test('multiple .sass imports in multiple blocks', () async {
+      var primary = makeAssetId('a|lib/styles.sass');
+      var import1 = makeAssetId('b|lib/more_styles.sass');
+      var import2 = makeAssetId('a|lib/_more_styles.sass');
+      var inputs = {
+        primary: '''@import 'package:b/more_styles'
+@import 'more_styles' ''',
+        import1: '''/* no imports */''',
+        import2: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import1, inputs[import1]);
+      reader.cacheStringAsset(import2, inputs[import2]);
+
+      await runBuilder(builder, [primary], reader, writer, null);
+
+      expect(
+          writer.assets.keys,
+          unorderedEquals([
+            primary.changeExtension('.css')
+          ]));
+
+      expect(reader.assetsRead, contains(primary));
+      expect(reader.assetsRead, contains(import1));
+      expect(reader.assetsRead, contains(import2));
+    });
   });
 }

--- a/test/sass_builder_test.dart
+++ b/test/sass_builder_test.dart
@@ -263,11 +263,8 @@ void main() {
 
       await runBuilder(builder, [primary], reader, writer, null);
 
-      expect(
-          writer.assets.keys,
-          unorderedEquals([
-            primary.changeExtension('.css')
-          ]));
+      expect(writer.assets.keys,
+          unorderedEquals([primary.changeExtension('.css')]));
 
       expect(reader.assetsRead, contains(primary));
       expect(reader.assetsRead, contains(import1));


### PR DESCRIPTION
Made regex for matching sass import rules a multiline regex because its $ sign was treated as the end of the string instead of the end of the line. This made it ignore all sass imports.

I added the test case "multiple .sass imports in multiple blocks" which fails with an error if the regex isn't multiline:

> Error: "package:" URLs aren't supported on this platform.
> @import 'package:b/more_styles'

The error message is misleading. Package URLs are supported but the stylesheet couldn't be found. The stylesheet should be in the temp directory because the method _importedAssets should have found it and the method _readAndCopyImports should have copied it into the temp folder.
