### PR TITLE
Add support for compressed output style

### DIFF
--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -74,12 +74,12 @@ class SassBuilder implements Builder {
   /// * If [_outputStyle] is not `sass.OutputStyle.compressed` or `sass.OutputStyle.expanded`,
   ///   a warning will be logged informing the user that the [_defaultOutputStyle] will be used.
   sass.OutputStyle _getValidOutputStyle() {
-    if (this._outputStyle == sass.OutputStyle.compressed.toString()) {
+    if (_outputStyle == sass.OutputStyle.compressed.toString()) {
       return sass.OutputStyle.compressed;
-    } else if (this._outputStyle == sass.OutputStyle.expanded.toString()) {
+    } else if (_outputStyle == sass.OutputStyle.expanded.toString()) {
       return sass.OutputStyle.expanded;
     } else {
-      _log.warning('Unknown outputStyle provided: "${this._outputStyle}". '
+      _log.warning('Unknown outputStyle provided: "$_outputStyle". '
           'Supported values are: "expanded" and "compressed". '
           'The default value of "${_defaultOutputStyle.toString()}" will be used.');
       return _defaultOutputStyle;

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -33,9 +33,13 @@ class SassBuilder implements Builder {
 
   final _log = new Logger('sass_builder');
   final String _outputExtension;
+  final String _outputStyle;
 
-  SassBuilder({String outputExtension: '.css'})
-      : this._outputExtension = outputExtension;
+  SassBuilder({String outputExtension: '.css', String outputStyle})
+      : this._outputExtension = outputExtension,
+        this._outputStyle = outputStyle ?? _defaultOutputStyle;
+
+  static final _defaultOutputStyle = OutputStyle.expanded.toString();
 
   @override
   Future build(BuildStep buildStep) async {
@@ -56,7 +60,10 @@ class SassBuilder implements Builder {
     var tempAssetPath = tempDir.fileFor(inputId).path;
     _log.fine('compiling file: ${tempAssetPath}');
     var cssOutput = compile(tempAssetPath,
-        packageResolver: new SyncPackageResolver.root(tempDir.packagesDir.uri));
+        packageResolver: new SyncPackageResolver.root(tempDir.packagesDir.uri),
+        style: this._outputStyle == _defaultOutputStyle
+            ? OutputStyle.expanded
+            : OutputStyle.compressed);
 
     // Write the builder output
     var outputId = inputId.changeExtension(_outputExtension);

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -39,7 +39,7 @@ class SassBuilder implements Builder {
       : this._outputExtension = outputExtension,
         this._outputStyle = outputStyle ?? _defaultOutputStyle;
 
-  static final _defaultOutputStyle = OutputStyle.expanded.toString();
+  static final _defaultOutputStyle = sass.OutputStyle.expanded.toString();
 
   @override
   Future build(BuildStep buildStep) async {
@@ -62,8 +62,8 @@ class SassBuilder implements Builder {
     var cssOutput = sass.compile(tempAssetPath,
         packageResolver: new SyncPackageResolver.root(tempDir.packagesDir.uri),
         style: this._outputStyle == _defaultOutputStyle
-            ? OutputStyle.expanded
-            : OutputStyle.compressed);
+            ? sass.OutputStyle.expanded
+            : sass.OutputStyle.compressed);
 
     // Write the builder output
     var outputId = inputId.changeExtension(_outputExtension);

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -37,9 +37,9 @@ class SassBuilder implements Builder {
 
   SassBuilder({String outputExtension: '.css', String outputStyle})
       : this._outputExtension = outputExtension,
-        this._outputStyle = outputStyle ?? _defaultOutputStyle;
+        this._outputStyle = outputStyle ?? _defaultOutputStyle.toString();
 
-  static final _defaultOutputStyle = sass.OutputStyle.expanded.toString();
+  static final _defaultOutputStyle = sass.OutputStyle.expanded;
 
   @override
   Future build(BuildStep buildStep) async {
@@ -61,14 +61,29 @@ class SassBuilder implements Builder {
     _log.fine('compiling file: ${tempAssetPath}');
     var cssOutput = sass.compile(tempAssetPath,
         packageResolver: new SyncPackageResolver.root(tempDir.packagesDir.uri),
-        style: this._outputStyle == _defaultOutputStyle
-            ? sass.OutputStyle.expanded
-            : sass.OutputStyle.compressed);
+        style: _getValidOutputStyle());
 
     // Write the builder output
     var outputId = inputId.changeExtension(_outputExtension);
     buildStep.writeAsString(outputId, '${cssOutput}\n');
     _log.fine('wrote css file: ${outputId.path}');
+  }
+
+  /// Returns a valid `OutputStyle` value to the `style` argument of [sass.compile] during a [build].
+  ///
+  /// * If [_outputStyle] is not `sass.OutputStyle.compressed` or `sass.OutputStyle.expanded`,
+  ///   a warning will be logged informing the user that the [_defaultOutputStyle] will be used.
+  sass.OutputStyle _getValidOutputStyle() {
+    if (this._outputStyle == sass.OutputStyle.compressed.toString()) {
+      return sass.OutputStyle.compressed;
+    } else if (this._outputStyle == sass.OutputStyle.expanded.toString()) {
+      return sass.OutputStyle.expanded;
+    } else {
+      _log.warning('Unknown outputStyle provided: "${this._outputStyle}". '
+          'Supported values are: "expanded" and "compressed". '
+          'The default value of "${_defaultOutputStyle.toString()}" will be used.');
+      return _defaultOutputStyle;
+    }
   }
 
   @override

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -6,7 +6,7 @@ import 'sass_builder.dart';
 class SassBuilderTransform extends BuilderTransformer {
   static final _outputExtensionKey = 'outputExtension';
   static final _outputStyleKey = 'outputStyle';
-  SassBuilderTransform() : super(new SassBuilder());
+  SassBuilderTransform(SassBuilder builder) : super(builder);
 
   SassBuilderTransform.customExtension(String outputExtension)
       : super(new SassBuilder(outputExtension: outputExtension));
@@ -15,14 +15,18 @@ class SassBuilderTransform extends BuilderTransformer {
       : super(new SassBuilder(outputStyle: outputStyle));
 
   factory SassBuilderTransform.asPlugin(BarbackSettings settings) {
+    SassBuilder builder;
+    var outputStyle = settings.configuration[_outputStyleKey] as String;
+
     if (settings.configuration.containsKey(_outputExtensionKey)) {
-      return new SassBuilderTransform.customExtension(
-          settings.configuration[_outputExtensionKey] as String);
+      builder = new SassBuilder(
+          outputExtension: settings.configuration[_outputExtensionKey] as String,
+          outputStyle: outputStyle,
+      );
+    } else {
+      builder = new SassBuilder(outputStyle: outputStyle);
     }
-    if (settings.configuration.containsKey(_outputStyleKey)) {
-      return new SassBuilderTransform.customOutputStyle(
-          settings.configuration[_outputStyleKey]);
-    }
-    return new SassBuilderTransform();
+
+    return new SassBuilderTransform(builder);
   }
 }

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -8,12 +8,6 @@ class SassBuilderTransform extends BuilderTransformer {
   static final _outputStyleKey = 'outputStyle';
   SassBuilderTransform(SassBuilder builder) : super(builder);
 
-  SassBuilderTransform.customExtension(String outputExtension)
-      : super(new SassBuilder(outputExtension: outputExtension));
-
-  SassBuilderTransform.customOutputStyle(String outputStyle)
-      : super(new SassBuilder(outputStyle: outputStyle));
-
   factory SassBuilderTransform.asPlugin(BarbackSettings settings) {
     SassBuilder builder;
     var outputStyle = settings.configuration[_outputStyleKey] as String;

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -5,15 +5,23 @@ import 'sass_builder.dart';
 /// A pub transformer simply wrapping the [SassBuilder].
 class SassBuilderTransform extends BuilderTransformer {
   static final _outputExtensionKey = 'outputExtension';
+  static final _outputStyleKey = 'outputStyle';
   SassBuilderTransform() : super(new SassBuilder());
 
   SassBuilderTransform.customExtension(String outputExtension)
       : super(new SassBuilder(outputExtension: outputExtension));
 
+  SassBuilderTransform.customOutputStyle(String outputStyle)
+      : super(new SassBuilder(outputStyle: outputStyle));
+
   factory SassBuilderTransform.asPlugin(BarbackSettings settings) {
     if (settings.configuration.containsKey(_outputExtensionKey)) {
       return new SassBuilderTransform.customExtension(
           settings.configuration[_outputExtensionKey] as String);
+    }
+    if (settings.configuration.containsKey(_outputStyleKey)) {
+      return new SassBuilderTransform.customOutputStyle(
+          settings.configuration[_outputStyleKey]);
     }
     return new SassBuilderTransform();
   }

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -20,8 +20,8 @@ class SassBuilderTransform extends BuilderTransformer {
 
     if (settings.configuration.containsKey(_outputExtensionKey)) {
       builder = new SassBuilder(
-          outputExtension: settings.configuration[_outputExtensionKey] as String,
-          outputStyle: outputStyle,
+        outputExtension: settings.configuration[_outputExtensionKey] as String,
+        outputStyle: outputStyle,
       );
     } else {
       builder = new SassBuilder(outputStyle: outputStyle);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ^0.11.3
   package_resolver: ^1.0.2
   path: ^1.4.1
-  sass: ^1.0.0-beta.4
+  sass: ^1.0.0-beta.5.1
   scratch_space: ^0.0.1
 dev_dependencies:
   bootstrap_sass: 4.0.0-alpha.5+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,14 +9,14 @@ description: Transpile sass files using the "build" package.
 environment:
   sdk: '>=1.8.0 <2.0.0'
 dependencies:
-  barback: ^0.15.2
+  barback: '>=0.15.2 <0.15.2+15'
   build: '>=0.11.1 <0.13.0'
   build_barback: '>=0.4.0+2 <0.6.0'
   build_config: ^0.2.1
   logging: ^0.11.3
   package_resolver: ^1.0.2
   path: ^1.4.1
-  sass: ^1.0.0-beta.5.1
+  sass: ^1.0.0
   scratch_space: ^0.0.1
 dev_dependencies:
   bootstrap_sass: 4.0.0-alpha.5+1


### PR DESCRIPTION
Proposed solution for #23, adding support for Sass' `OutputStyle.compressed` (https://github.com/sass/dart-sass/pull/217).

@luisvt @kevmoo @nshahan 
