### PR TITLE
Prep to publish v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+* Add option to configure output style. Supports `expanded` or `compressed` as 
+  provided by the Dart implementation of Sass. Defaults to `expanded`.
+* Removed dev dependencies that were no longer used.
+
 ## 1.1.5
 
 * Fix a bug where the class `Logger` conflicted with `sass`, causing a crash.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ of [sass][2].
 [1]: https://github.com/dart-lang/build
 [2]: https://github.com/sass/dart-sass
 
-##Attention: Transformer to be Removed 
+## Attention: Transformer to be Removed 
 
 > The transformer provided by this package will be deprecated and removed soon. 
 > The `pub build` and `pub serve` commands are being replaced by `build_runner`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ of [sass][2].
 [1]: https://github.com/dart-lang/build
 [2]: https://github.com/sass/dart-sass
 
+##Attention: Transformer to be Removed 
+
+> The transformer provided by this package will be deprecated and removed soon. 
+> The `pub build` and `pub serve` commands are being replaced by `build_runner`.
+>
+> * [Announcement](https://groups.google.com/a/dartlang.org/forum/#!topic/announce/R4kV3us0Sm8)
+> * [Migration Guide](https://webdev-dartlang-org-dev.firebaseapp.com/dart-2#tools)
+
 ## Usage
 
 1\. Create a `pubspec.yaml` file containing the following code:
@@ -82,6 +90,25 @@ dev_dependencies:
 }
 ```
 
+### Builder Options
+
+To configure options for the builder see the `build_config` 
+[README](https://github.com/dart-lang/build/blob/master/build_config/README.md). 
+
+* `outputStyle`: Supports `expanded` or `compressed`. Defaults to `expanded`.
+
+Example:
+
+```yaml
+targets:
+  $default:
+    builders:
+      sass_builder:
+        options:
+          outputStyle: compressed
+```
+
+
 ## Wrapped as a Pub Transformer
 
 To automatically generate .css files when you run `pub build` or `pub serve`
@@ -96,11 +123,16 @@ transformers:
 - sass_builder
 ```
 
-By default this will generate .css files for every non-partial .scss file in your project.
- You can customize the extension of the generated files with the `outputExtension` option:
+### Transformer Options
+
+* `outputExtension`: The extension to use for output files. Defaults to `.css`.
+* `outputStyle`: Supports `expanded` and `compressed`. Defautls to `expanded`.
+
+Example:
 
 ```yaml
 transformers:
 - sass_builder:
     outputExtension: .scss.css
+    outputStyle: compressed
 ```

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -18,8 +18,10 @@ final _scssfileNameRegExp = new RegExp(r'''(?:\'|\")([^\'\"]*)(?:\'|\")''');
 final _sassfileNameRegExp = new RegExp(r'''['"]?([^ ,'"]+)['"]?''');
 final _scssCommentRegExp =
     new RegExp(r'''//.*?\n|/\*.*?\*/''', multiLine: true);
+final outputStyleKey = 'outputStyle';
 
-Builder sassBuilder(_) => new SassBuilder();
+Builder sassBuilder(BuilderOptions options) =>
+    new SassBuilder(outputStyle: options.config[outputStyleKey]);
 
 /// A `Builder` to compile .css files from .scss source using dart-sass.
 ///
@@ -69,10 +71,12 @@ class SassBuilder implements Builder {
     _log.fine('wrote css file: ${outputId.path}');
   }
 
-  /// Returns a valid `OutputStyle` value to the `style` argument of [sass.compile] during a [build].
+  /// Returns a valid `OutputStyle` value to the `style` argument of
+  /// [sass.compile] during a [build].
   ///
-  /// * If [_outputStyle] is not `sass.OutputStyle.compressed` or `sass.OutputStyle.expanded`,
-  ///   a warning will be logged informing the user that the [_defaultOutputStyle] will be used.
+  /// * If [_outputStyle] is not `sass.OutputStyle.compressed` or
+  /// `sass.OutputStyle.expanded`, a warning will be logged informing the user
+  /// that the [_defaultOutputStyle] will be used.
   sass.OutputStyle _getValidOutputStyle() {
     if (_outputStyle == sass.OutputStyle.compressed.toString()) {
       return sass.OutputStyle.compressed;
@@ -80,8 +84,8 @@ class SassBuilder implements Builder {
       return sass.OutputStyle.expanded;
     } else {
       _log.warning('Unknown outputStyle provided: "$_outputStyle". '
-          'Supported values are: "expanded" and "compressed". '
-          'The default value of "${_defaultOutputStyle.toString()}" will be used.');
+          'Supported values are: "expanded" and "compressed". The default '
+          'value of "${_defaultOutputStyle.toString()}" will be used.');
       return _defaultOutputStyle;
     }
   }

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -5,12 +5,11 @@ import 'sass_builder.dart';
 /// A pub transformer simply wrapping the [SassBuilder].
 class SassBuilderTransform extends BuilderTransformer {
   static final _outputExtensionKey = 'outputExtension';
-  static final _outputStyleKey = 'outputStyle';
   SassBuilderTransform(SassBuilder builder) : super(builder);
 
   factory SassBuilderTransform.asPlugin(BarbackSettings settings) {
     SassBuilder builder;
-    var outputStyle = settings.configuration[_outputStyleKey] as String;
+    var outputStyle = settings.configuration[outputStyleKey] as String;
 
     if (settings.configuration.containsKey(_outputExtensionKey)) {
       builder = new SassBuilder(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_builder
-version: 1.1.5
+version: 1.2.0
 authors:
 - Luis Vargas <luisvargastijerino@gmail.com>
 - Kevin Moore <kevmoo@github.com>
@@ -19,7 +19,5 @@ dependencies:
   sass: ^1.0.0
   scratch_space: ^0.0.1
 dev_dependencies:
-  bootstrap_sass: 4.0.0-alpha.5+1
   build_test: '>=0.9.1 <0.11.0'
-  build_runner: ^0.7.0
   test: ^0.12.0


### PR DESCRIPTION
* Allow builder to use new `outputStyle` option.
* Remove unused dev dependencies.
* CHANGELOG and README updates.