### PR TITLE
Add cleanup of SASS source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.1
+
+* Add a builder which will clean up `.scss` and `.sass` sources for `--release`
+  builds.
+
 ## 1.2.0
 
 * Add option to configure output style. Supports `expanded` or `compressed` as 

--- a/build.yaml
+++ b/build.yaml
@@ -1,9 +1,17 @@
 builders:
   sass_builder:
-    target: "sass_builder"
     import: "package:sass_builder/sass_builder.dart"
     builder_factories: ["sassBuilder"]
     auto_apply: dependents
     build_extensions:
       .scss: [".css"]
       .sass: [".css"]
+    applies_builders:
+      - sass_builder|sass_source_cleanup
+post_process_builders:
+  sass_source_cleanup:
+    import: "package:sass_builder/sass_builder.dart"
+    builder_factory: "sassSourceCleanup"
+    defaults:
+      release_options:
+        enabled: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,6 +5,6 @@ environment:
 dependencies:
   bootstrap_sass: 4.0.0-alpha.5+1
 dev_dependencies:
-  build_runner: ^0.7.6
+  build_runner: ^0.8.8
   sass_builder:
     path: ../

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -23,6 +23,10 @@ final outputStyleKey = 'outputStyle';
 Builder sassBuilder(BuilderOptions options) =>
     new SassBuilder(outputStyle: options.config[outputStyleKey]);
 
+PostProcessBuilder sassSourceCleanup(BuilderOptions options) =>
+    new FileDeletingBuilder(['.scss', '.sass'],
+        isEnabled: (options.config['enabled'] as bool) ?? false);
+
 /// A `Builder` to compile .css files from .scss source using dart-sass.
 ///
 /// NOTE: Because Sass requires reading from the disk this `Builder` copies all

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_builder
-version: 1.2.0
+version: 1.2.1-dev
 authors:
 - Luis Vargas <luisvargastijerino@gmail.com>
 - Kevin Moore <kevmoo@github.com>
@@ -7,12 +7,12 @@ authors:
 homepage: https://github.com/dart-league/sass_builder
 description: Transpile sass files using the "build" package.
 environment:
-  sdk: '>=1.8.0 <2.0.0'
+  sdk: '>=2.0.0-dev.9 <2.0.0'
 dependencies:
   barback: '>=0.15.2 <0.15.2+15'
-  build: '>=0.11.1 <0.13.0'
+  build: ^0.12.5
   build_barback: '>=0.4.0+2 <0.6.0'
-  build_config: ^0.2.1
+  build_config: ^0.2.6
   logging: ^0.11.3
   package_resolver: ^1.0.2
   path: ^1.4.1


### PR DESCRIPTION
See https://github.com/dart-lang/build/issues/1308

- Add a post process builder to remove .scss and .sass files. Enabled by
  default only in release mode.
- Upgrade the minimum version of `package:build` to one that include
  `PostProcessBuilder` and `FileDeletingBuilder`.
- Updgrae the mininmum version of `package:build_config` to one that
  includes parsing of the `post_process_builders` section.
- Drop the now unnecessary `target` config for the builder.
- Upgrade the `build_runner` version in the example directory to one
  that supports `--release`

See the difference in the example by building to an output directory
with and without the `--release` flag.