### PR TITLE
Support includePath as an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ To configure options for the builder see the `build_config`
 
 * `outputStyle`: Supports `expanded` or `compressed`. Defaults to `expanded` in
   dev mode, and `compressed` in release mode.
-* `includePaths`: Supports adding a list of  directories that will be searched 
-  as part of an @include directive. Note that these files must still be readable by
-  the build system, which means putting them usually in web/ or lib/.
+* `includePaths`: Supports adding a list of directories that will be searched
+  as part of an @include directive. Note that these files must still be
+  readable by the build system, which means putting them usually in web/ or
+  lib/.
 
 Example that compresses output in dev mode:
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ To configure options for the builder see the `build_config`
 * `includePaths`: Supports adding a list of directories that will be searched
   as part of an @include directive. Note that these files must still be
   readable by the build system, which means putting them usually in web/ or
-  lib/.
+  lib/. Also note that include paths are processed in order and will use the
+  first matching file or partial.
 
 Example that compresses output in dev mode:
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ To configure options for the builder see the `build_config`
 
 * `outputStyle`: Supports `expanded` or `compressed`. Defaults to `expanded` in
   dev mode, and `compressed` in release mode.
+* `includePaths`: Supports adding a list of  directories that will be searched 
+  as part of an @include directive. Note that these files must still be readable by
+  the build system, which means putting them usually in web/ or lib/.
 
 Example that compresses output in dev mode:
 
@@ -108,4 +111,16 @@ targets:
       sass_builder:
         options:
           outputStyle: compressed
+```
+
+Example that adds 'web/node_modules' to the Sass search paths
+
+```yaml
+targets:
+  $default:
+    builders:
+      sass_builder:
+        options:
+          includePaths:
+            - web/node_modules
 ```

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -45,10 +45,12 @@ class SassBuilder implements Builder {
 
     // Compile the css.
     log.fine('compiling file: ${inputId.uri.toString()}');
+    final importers = [new BuildImporter(buildStep)].followedBy(_includePaths
+        .map((includePath) => new BuildImporter(buildStep, includePath)));
     final cssOutput = await sass.compileStringAsync(
         await buildStep.readAsString(inputId),
         syntax: sass.Syntax.forPath(inputId.path),
-        importers: [new BuildImporter(buildStep, _includePaths)],
+        importers: importers,
         style: _getValidOutputStyle());
 
     // Write the builder output.

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -7,9 +7,12 @@ import 'package:sass/sass.dart' as sass;
 import 'src/build_importer.dart';
 
 final outputStyleKey = 'outputStyle';
+final includePathsKey = 'includePaths';
 
 Builder sassBuilder(BuilderOptions options) =>
-    new SassBuilder(outputStyle: options.config[outputStyleKey]);
+    new SassBuilder(
+      outputStyle: options.config[outputStyleKey], 
+      includePaths: options.config[includePathsKey].cast<String>());
 
 PostProcessBuilder sassSourceCleanup(BuilderOptions options) =>
     new FileDeletingBuilder(['.scss', '.sass'],
@@ -21,10 +24,12 @@ class SassBuilder implements Builder {
   static final _defaultOutputStyle = sass.OutputStyle.expanded;
   final String _outputExtension;
   final String _outputStyle;
+  final List<String> _includePaths;
 
-  SassBuilder({String outputExtension: '.css', String outputStyle})
+  SassBuilder({String outputExtension: '.css', String outputStyle, List<String> includePaths: const []})
       : this._outputExtension = outputExtension,
-        this._outputStyle = outputStyle ?? _defaultOutputStyle.toString();
+        this._outputStyle = outputStyle ?? _defaultOutputStyle.toString(),
+        this._includePaths = includePaths ?? [];
 
   @override
   Future build(BuildStep buildStep) async {
@@ -41,7 +46,7 @@ class SassBuilder implements Builder {
     final cssOutput = await sass.compileStringAsync(
         await buildStep.readAsString(inputId),
         indented: inputId.extension == '.sass',
-        importers: [new BuildImporter(buildStep)],
+        importers: [new BuildImporter(buildStep, _includePaths)],
         style: _getValidOutputStyle());
 
     // Write the builder output.

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -9,10 +9,9 @@ import 'src/build_importer.dart';
 final outputStyleKey = 'outputStyle';
 final includePathsKey = 'includePaths';
 
-Builder sassBuilder(BuilderOptions options) =>
-    new SassBuilder(
-      outputStyle: options.config[outputStyleKey], 
-      includePaths: options.config[includePathsKey].cast<String>());
+Builder sassBuilder(BuilderOptions options) => new SassBuilder(
+    outputStyle: options.config[outputStyleKey],
+    includePaths: options.config[includePathsKey].cast<String>());
 
 PostProcessBuilder sassSourceCleanup(BuilderOptions options) =>
     new FileDeletingBuilder(['.scss', '.sass'],
@@ -26,7 +25,10 @@ class SassBuilder implements Builder {
   final String _outputStyle;
   final List<String> _includePaths;
 
-  SassBuilder({String outputExtension: '.css', String outputStyle, List<String> includePaths: const []})
+  SassBuilder(
+      {String outputExtension: '.css',
+      String outputStyle,
+      List<String> includePaths: const []})
       : this._outputExtension = outputExtension,
         this._outputStyle = outputStyle ?? _defaultOutputStyle.toString(),
         this._includePaths = includePaths ?? [];

--- a/lib/src/build_importer.dart
+++ b/lib/src/build_importer.dart
@@ -62,12 +62,11 @@ class BuildImporter extends sass.AsyncImporter {
     if (await _buildStep.canRead(importId)) imports.add(importId);
 
     for (var includePath in _includePaths) {
-      final partialId = new AssetId.resolve(
-        p.url.join(
+      final partialId = new AssetId.resolve(p.url.join(
           'asset:${_buildStep.inputId.package}/${includePath}',
           p.dirname(import),
           '_${p.basename(import)}'));
-      if(await _buildStep.canRead(partialId)) imports.add(partialId);
+      if (await _buildStep.canRead(partialId)) imports.add(partialId);
       final importId = new AssetId.resolve(p.url
           .join('asset:${_buildStep.inputId.package}/${includePath}', import));
       if (await _buildStep.canRead(importId)) imports.add(importId);

--- a/lib/src/build_importer.dart
+++ b/lib/src/build_importer.dart
@@ -11,8 +11,9 @@ import 'package:sass/sass.dart' as sass;
 /// https://github.com/sass/dart-sass/blob/f8b2c9111c1d5a3c07c9c8c0828b92bd87c548c9/lib/src/importer/utils.dart
 class BuildImporter extends sass.AsyncImporter {
   final BuildStep _buildStep;
+  final List<String> _includePaths;
 
-  BuildImporter(this._buildStep);
+  BuildImporter(this._buildStep, this._includePaths);
 
   @override
   FutureOr<Uri> canonicalize(Uri url) async =>
@@ -59,6 +60,19 @@ class BuildImporter extends sass.AsyncImporter {
     if (await _buildStep.canRead(partialId)) imports.add(partialId);
     final importId = new AssetId.resolve(import, from: _buildStep.inputId);
     if (await _buildStep.canRead(importId)) imports.add(importId);
+
+    for (var includePath in _includePaths) {
+      final partialId = new AssetId.resolve(
+        p.url.join(
+          'asset:${_buildStep.inputId.package}/${includePath}',
+          p.dirname(import),
+          '_${p.basename(import)}'));
+      if(await _buildStep.canRead(partialId)) imports.add(partialId);
+      final importId = new AssetId.resolve(p.url
+          .join('asset:${_buildStep.inputId.package}/${includePath}', import));
+      if (await _buildStep.canRead(importId)) imports.add(importId);
+    }
+
     return imports;
   }
 

--- a/test/sass_builder_test.dart
+++ b/test/sass_builder_test.dart
@@ -193,6 +193,47 @@ void main() {
       expect(reader.assetsRead, containsAll([primary, import1, import2]));
     });
 
+    test('consults include path', () async {
+      var primary = makeAssetId('a|lib/syles.scss');
+      var import = makeAssetId('a|search_path/module/styles.scss');
+      var inputs = {
+        primary: '''@import 'module/styles';''',
+        import: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import, inputs[import]);
+
+      builder = SassBuilder(includePaths: ['search_path']);
+
+      await runBuilder(builder, inputs.keys, reader, writer, null);
+
+      expect(writer.assets.keys, unorderedEquals([
+        primary.changeExtension('.css'),
+        import.changeExtension('.css')
+      ]));
+      expect(reader.assetsRead, containsAll([primary, import]));
+    });
+
+    test('consults include path for partials', () async {
+      var primary = makeAssetId('a|lib/syles.scss');
+      var import = makeAssetId('a|search_path/module/_styles.scss');
+      var inputs = {
+        primary: '''@import 'module/styles';''',
+        import: '''/* no imports */''',
+      };
+
+      reader.cacheStringAsset(primary, inputs[primary]);
+      reader.cacheStringAsset(import, inputs[import]);
+
+      builder = SassBuilder(includePaths: ['search_path']);
+
+      await runBuilder(builder, inputs.keys, reader, writer, null);
+
+      expect(writer.assets.keys, equals([primary.changeExtension('.css')]));
+      expect(reader.assetsRead, containsAll([primary, import]));
+    });
+
     test('.sass file import parsing', () async {
       var primary = makeAssetId('a|lib/styles.sass');
       var import1 = makeAssetId('a|lib/_more_styles.sass');

--- a/test/sass_builder_test.dart
+++ b/test/sass_builder_test.dart
@@ -208,10 +208,12 @@ void main() {
 
       await runBuilder(builder, inputs.keys, reader, writer, null);
 
-      expect(writer.assets.keys, unorderedEquals([
-        primary.changeExtension('.css'),
-        import.changeExtension('.css')
-      ]));
+      expect(
+          writer.assets.keys,
+          unorderedEquals([
+            primary.changeExtension('.css'),
+            import.changeExtension('.css')
+          ]));
       expect(reader.assetsRead, containsAll([primary, import]));
     });
 


### PR DESCRIPTION
This allows for use of things like the material_components_web node_module which assumes that the root @material directory is searchable on an include path.

Note that includePaths still need to be readable by the build