### PR TITLE
Allow build_config 0.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+* Widen version constrain on `build_config`.
+
 ## 2.1.2
 
 ### Maintenance Release

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_builder
-version: 2.1.2
+version: 2.1.3
 
 authors:
 - Luis Vargas <luisvargastijerino@gmail.com>
@@ -14,7 +14,7 @@ environment:
 
 dependencies:
   build: '>=0.12.5 <2.0.0'
-  build_config: ^0.3.0
+  build_config: '>=0.3.0 <0.5.0'
   path: ^1.4.1
   sass: '>=1.11.0 <2.0.0'
 


### PR DESCRIPTION
There were breaking changes for the build system, but nothing breaking
for parsing `build.yaml`.