### PR TITLE
Use proper name to resolve `OutputStyle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+- Fix a bug reading builder options with new Sass versions.
+
 ## 2.1.4
 
 - Support latest versions of all dependencies

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -19,6 +19,8 @@ PostProcessBuilder sassSourceCleanup(BuilderOptions options) =>
 /// the dart implementation of Sass.
 class SassBuilder implements Builder {
   static final _defaultOutputStyle = sass.OutputStyle.expanded;
+  static final _outputStylesByName = sass.OutputStyle.values.asNameMap();
+
   final String _outputExtension;
   final String _outputStyle;
 
@@ -60,10 +62,10 @@ class SassBuilder implements Builder {
   /// `OutputStyle.expanded`, a warning will be logged informing the user
   /// that the [_defaultOutputStyle] will be used.
   sass.OutputStyle _getValidOutputStyle() {
-    if (_outputStyle == sass.OutputStyle.compressed.toString()) {
-      return sass.OutputStyle.compressed;
-    } else if (_outputStyle == sass.OutputStyle.expanded.toString()) {
-      return sass.OutputStyle.expanded;
+    final style = _outputStylesByName[_outputStyle];
+
+    if (style != null) {
+      return style;
     } else {
       log.warning('Unknown outputStyle provided: "$_outputStyle". '
           'Supported values are: "expanded" and "compressed". The default '

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_builder
-version: 2.1.4
+version: 2.1.5
 
 homepage: https://github.com/dart-league/sass_builder
 description: Transpile sass files using the "build" package.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/dart-league/sass_builder
 description: Transpile sass files using the "build" package.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   build: ^2.0.0
   build_config: ^1.0.0
   path: ^1.8.0
-  sass: ^1.32.10
+  sass: ^1.55.0
 
 dev_dependencies:
   build_test: ^2.0.0


### PR DESCRIPTION
In a recent sass version (I don't know which one, it's not mentioned in the changelog), `OutputStyle` has been changed from a regular class to an enum. They also stopped overriding `toString()`, which is why our logic to resolve the output style is failing now.

In this PR, I fix that by using a name map for that enum. I'm also raising the min SDK to Dart 2.15 for `Enum.name` to be available and sass to the latest version because I could not easily determine the sass version making that change.

Closes #66.