### PR TITLE
Use logger from package:build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 2.4.0-dev
+
+- Use logger from `package:build` to emit Sass logs.
+
 ## 2.3.1
 
-- Support version 4 of `pacakge:build`.
+- Support version 4 of `package:build`.
 
 ## 2.3.0
 

--- a/lib/sass_builder.dart
+++ b/lib/sass_builder.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:sass/sass.dart' as sass;
 
 import 'src/build_importer.dart';
+import 'src/logger.dart';
 
 const outputStyleKey = 'outputStyle';
 
@@ -54,6 +55,7 @@ class SassBuilder implements Builder {
       style: _getValidOutputStyle(),
       url: inputId.uri,
       sourceMap: _generateSourceMaps,
+      logger: LoggingAdapter(log),
     );
 
     var cssOutput = compileResult.css;

--- a/lib/src/logger.dart
+++ b/lib/src/logger.dart
@@ -1,0 +1,30 @@
+import 'package:logging/logging.dart' as logging;
+import 'package:sass/sass.dart' as sass;
+import 'package:source_span/source_span.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+final class LoggingAdapter implements sass.Logger {
+  final logging.Logger _logger;
+
+  LoggingAdapter(this._logger);
+
+  @override
+  void debug(String message, SourceSpan span) {
+    _logger.fine(span.message(message, color: true));
+  }
+
+  @override
+  void warn(String message,
+      {FileSpan? span, Trace? trace, bool deprecation = false}) {
+    final highlightedMessage = switch (span) {
+      null => message,
+      final span => span.message(message, color: true),
+    };
+
+    if (trace == null) {
+      _logger.warning(highlightedMessage);
+    } else {
+      _logger.warning(highlightedMessage, '', trace);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_builder
-version: 2.3.1
+version: 2.4.0-dev
 repository: https://github.com/dart-league/sass_builder
 description: Transpile sass files using the "build" package.
 
@@ -9,8 +9,11 @@ environment:
 dependencies:
   build: '>=3.0.0 <5.0.0'
   build_config: ^1.2.0
+  logging: ^1.3.0
   path: ^1.8.0
   sass: ^1.74.0
+  source_span: ^1.10.1
+  stack_trace: ^1.12.1
 
 dev_dependencies:
   build_test: ^3.3.2

--- a/test/sass_builder_test.dart
+++ b/test/sass_builder_test.dart
@@ -334,6 +334,29 @@ void main() {
           'be used.')),
     );
   });
+
+  test('uses build logger to forward sass errors', () async {
+    final messages = <String>[];
+    await testBuilder(
+      sassBuilder(BuilderOptions({}, isRoot: true)),
+      {
+        'a|web/styles.scss': '''
+          @use 'package:unknown/stylesheet';
+        ''',
+      },
+      outputs: {},
+      onLog: (log) => messages.add(log.message),
+    );
+
+    expect(
+      messages,
+      anyElement(allOf(
+        contains('SassBuilder on web/styles.scss'),
+        contains("Can't find stylesheet to import."),
+        contains("@use 'package:unknown/stylesheet';"),
+      )),
+    );
+  });
 }
 
 extension on ReaderWriterTesting {


### PR DESCRIPTION
Use the `log` instance provided to builders instead of letting Sass emit warnings directly to `stderr`.